### PR TITLE
allow abort for sleep

### DIFF
--- a/threading/sleep.js
+++ b/threading/sleep.js
@@ -1,6 +1,24 @@
 
-const sleep = milliseconds => value => new Promise(
-  resolve => setTimeout(() => resolve(value), milliseconds),
-)
+const sleep = (milliseconds, {signal} = {}) => value => {
+
+   if (signal) {
+        if (signal.aborted) {
+            return Promise.reject(new DOMException("AbortError"))
+        }
+   }
+    return new Promise((resolve, reject) => {
+        let timeoutId
+        if (signal) {
+             signal.onabort = () => {
+                 if (timeoutId) {
+                     clearTimeout(timeoutId)
+                     timeoutId = undefined
+                     reject(new DOMException("AbortError"))
+                 }
+             }
+        }
+        timeoutId = setTimeout(() => resolve(value), milliseconds)
+    })
+}
 
 module.exports = sleep


### PR DESCRIPTION
Example

```
const controller = new AbortController()
const signal = controller.signal
sleep(100, {signal})(2222).then(console.log).catch(console.error)
controller.abort()
```