### PR TITLE
fix #272: fixed a typo in is.mdx

### DIFF
--- a/logic/unless.mdx
+++ b/logic/unless.mdx
@@ -16,7 +16,7 @@ import log from 'mojiscript/console/log'
 import pipe from 'mojiscript/core/pipe'
 import run from 'mojiscript/core/run'
 import unless from 'mojiscript/logic/unless'
-import is from 'mojiscript/types/is'
+import is from 'mojiscript/type/is'
 
 const state = 1
 

--- a/logic/when.mdx
+++ b/logic/when.mdx
@@ -16,7 +16,7 @@ import log from 'mojiscript/console/log'
 import pipe from 'mojiscript/core/pipe'
 import run from 'mojiscript/core/run'
 import when from 'mojiscript/logic/when'
-import is from 'mojiscript/types/is'
+import is from 'mojiscript/type/is'
 
 const state = 'mojiscript'
 

--- a/type/is.mdx
+++ b/type/is.mdx
@@ -15,7 +15,7 @@ Checks the type of an `Object`.
 import log from 'mojiscript/console/log'
 import pipe from 'mojiscript/core/pipe'
 import run from 'mojiscript/core/run'
-import is from 'mojiscript/types/is'
+import is from 'mojiscript/type/is'
 
 const main = pipe ([
   () => log (is (Function) (x => x)),        //=> true


### PR DESCRIPTION
Before

```js
import is from 'mojiscript/types/is'
```

After

```js
import is from 'mojiscript/type/is'
```